### PR TITLE
Update front-end-cicd.yaml

### DIFF
--- a/.github/workflows/front-end-cicd.yaml
+++ b/.github/workflows/front-end-cicd.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - uses: jakejarvis/s3-sync-action@master
+    - uses: jakejarvis/s3-sync-action@be0c4ab89158cac4278689ebedd8407dd5f35a83 #
       with:
         args: --acl private --follow-symlinks --delete
       env:


### PR DESCRIPTION
Security fix: Pin jakejarvis/s3-sync-action to a commit SHA to prevent supply chain risks. 

Fixes GHSA-483p-rqgg-87rf

## Mitigation Steps
**Step 1:** 
- Identify the latest stable commit SHA for `jakejarvis/s3-sync-action@v0.5.1`.

**Step 2:** 
- Update `.github/workflows/front-end-cicd.yaml` to reference the commit SHA instead of a floating tag.

**Step 3:** 
- Test the workflow to ensure expected functionality.

**Step 4:** 
- Merge the fix and document the change for visibility.

**Step 5:** 
- Enable GitHub Actions security updates via Dependabot to receive alerts for any changes.

## Security Best Practices Going Forward
- Always pin third-party GitHub Actions to a commit SHA.
- Regularly audit dependencies in CI/CD workflows.
- Enable GitHub Dependabot alerts for Actions to detect outdated or vulnerable dependencies.
- Minimize GitHub Actions permissions to follow the principle of least privilege.
