### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/MrGuato/AWS-Cloud-Challenge/security/code-scanning/9](https://github.com/MrGuato/AWS-Cloud-Challenge/security/code-scanning/9)

To fix the issue, add a `permissions` block to the root of the workflow file. This block will explicitly define the permissions required for the workflow, limiting the `GITHUB_TOKEN` to read-only access to repository contents. Since the workflow does not require write access to the repository, the minimal permissions should be set as `contents: read`.

The `permissions` block should be added at the top level of the workflow file, ensuring it applies to all jobs in the workflow.

